### PR TITLE
Fix macro directory PopOut, upgrade module for v11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea/
 *.lock

--- a/module.json
+++ b/module.json
@@ -1,6 +1,5 @@
 {
 	"id": "sidebar-macros",
-	"name": "sidebar-macros",
 	"title": "Sidebar Macros",
 	"description": "Add Macros to the Foundry VTT sidebar!",
 	"authors": [
@@ -22,11 +21,9 @@
 	},
 	"version": "This is auto replaced",
 	"compatibility": {
-		"minimum": "0.7.9",
-		"verified": "10"
+		"minimum": "11",
+		"verified": "11.315"
 	},
-	"minimumCoreVersion": "0.7.9",
-	"compatibleCoreVersion": "10",
 	"esmodules": [
 		"scripts/sidebar-macros.js"
 	],

--- a/scripts/sidebar-macros.js
+++ b/scripts/sidebar-macros.js
@@ -71,7 +71,7 @@ Hooks.on("renderSidebar", (_app, html) => {
 // Hook into the sidebar tab rendering
 Hooks.on("renderSidebarTab", (doc, html) => {
 	// If we are rendering the "macros" sidebar tab
-	if (doc.tabName === "macros") {
+	if (doc.tabName === "macros" && !doc.popOut) {
 		// Create the Macro directory
 		createDirectory(html[0]);
 	}

--- a/scripts/sidebar-macros.js
+++ b/scripts/sidebar-macros.js
@@ -42,17 +42,6 @@ Hooks.on("init", () => {
 
 // Hook into the sidebar rendering
 Hooks.on("renderSidebar", (_app, html) => {
-	// Add CSS variables if not v9
-	if ((game.version && !isNewerVersion(game.version, 9)) ?? true) {
-		html[0].style.setProperty("--sidebar-width", getComputedStyle(html[0]).width);
-		html[0]
-			.querySelectorAll("#sidebar-tabs > .item ")
-			.forEach(el => (el.style.flex = "0 0 var(--sidebar-tab-width)"));
-	}
-
-	// Render the macro sidebar directory (needed for 0.7.x)
-	ui.macros.render(true);
-
 	// Calculate new tab width
 	html[0]
 		.querySelector("#sidebar-tabs")
@@ -141,31 +130,16 @@ Hooks.on("init", () => (CONFIG.ui.macros = MacroSidebarDirectory));
 // The following code up to line 110 was mostly taken from `foundry.js` to ensure that this module works and is licensed under the Foundry Virtual Tabletop Limited License Agreement for module development
 /**
  * The directory, displayed in the Sidebar, which organizes and displays world-level Macro documents.
- * @extends {SidebarDirectory}
+ * @extends {DocumentDirectory}
  *
- * @see {@link MacroDirectory}  The Macro Directory not displayed in the Sidebar
- * @see {@link Macros}          The WorldCollection of Macro Entities
- * @see {@link Macro}           The Macro Entity
- * @see {@link MacroConfig}     The Macro Configuration Sheet
+ * @see {MacroDirectory}  The Macro Directory not displayed in the Sidebar
+ * @see {Macros}          The WorldCollection of Macro Entities
+ * @see {Macro}           The Macro Entity
+ * @see {MacroConfig}     The Macro Configuration Sheet
  */
-class MacroSidebarDirectory extends SidebarDirectory {
-	constructor(options = {}) {
-		super(options);
-		if (ui.sidebar) ui.sidebar.tabs.macros = this;
-		game.macros.apps.push(this);
-	}
-
+class MacroSidebarDirectory extends DocumentDirectory {
 	/** @override */
 	static documentName = "Macro";
-
-	/** @override */
-	static get entity() {
-		return "Macro";
-	}
-	/** @override */
-	static get collection() {
-		return game.macros;
-	}
 
 	/** @override */
 	activateListeners(html) {
@@ -186,14 +160,7 @@ class MacroSidebarDirectory extends SidebarDirectory {
 				icon: `<i class="fas fa-terminal"></i>`,
 				condition: data => {
 					const macro = game.macros.get(data[0].dataset.entityId || data[0].dataset.documentId);
-					return (
-						macro.data.type === "script" &&
-						(macro.permission === (CONST.ENTITY_PERMISSIONS?.OWNER ?? CONST.DOCUMENT_PERMISSION_LEVELS.OWNER) ||
-							macro.testUserPermission(
-								game.user,
-								CONST.ENTITY_PERMISSIONS?.OWNER ?? CONST.DOCUMENT_PERMISSION_LEVELS.OWNER
-							))
-					);
+					return macro.canExecute;
 				},
 				callback: data => {
 					const macro = game.macros.get(data[0].dataset.entityId || data[0].dataset.documentId);
@@ -212,7 +179,7 @@ class MacroSidebarDirectory extends SidebarDirectory {
 		event.preventDefault();
 		const element = event.currentTarget;
 		const documentId = element.parentElement.dataset.documentId ?? element.parentElement.dataset.entityId;
-		const document = this.constructor.collection.get(documentId);
+		const document = this.collection.get(documentId);
 		document.execute();
 	}
 }


### PR DESCRIPTION
## Changelog
1. Fixed right clicking on macro tab muliplying instead of popping out (video below)
2. Updated code for Foundry v11, including change from **_deprecated_** `SidebarDirectory` to `DocumentDirectory`
3. Removed needless getters and other practically useless code 
4. Removed legacy support (since we are moving away from deprecated class anyway)
5. Set new minimum Foundry version and removed legacy attributes from manifest

## Directory multiplication bug due to disabled popout
![](https://i.gyazo.com/3d5117127bb5f39a9176a820c3f42e9d.gif)

Resolves #22